### PR TITLE
add mongodb docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 mongo:
   image: mongo
-  restart: always
   ports:
     - "27017:27017"


### PR DESCRIPTION
To get started with the application 
I need Rabbitmq and MongoDB.

configServer Rabbitmq docker-compose.yml
The file exists. 
However, the mongoDB docker-compose.yml file does not exist in the Client project.

I thought it would be nice to add it for the convenience of the developers. 
Added successfully.